### PR TITLE
replace httr::GET() with httr::RETRY()

### DIFF
--- a/R/MODIStsp_download.R
+++ b/R/MODIStsp_download.R
@@ -157,11 +157,12 @@ MODIStsp_download <- function(modislist,
                                    intern = Sys.info()["sysname"] == "Windows"))
           } else {
             # http download - httr
-            download <- try(httr::GET(remote_filename,
-                                      httr::authenticate(user, password),
-                                      # httr::progress(),
-                                      httr::write_disk(local_filename,
-                                                       overwrite = TRUE)))
+            download <- try(httr::RETRY("GET", remote_filename,
+                                        httr::authenticate(user, password),
+                                        # httr::progress(),
+                                        httr::write_disk(local_filename,
+                                                         overwrite = TRUE),
+                                        terminate_on = c(403, 404)))
           }
         }
 


### PR DESCRIPTION
Thanks for this awesome project!

In this PR, I'd like to propose swapping out calls to httr::GET() etc. with httr::RETRY(). This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on chircollab/chircollab20#1 as part of Chicago R Collab, an R 'unconference' in Chicago.