### PR TITLE
Fix error due to unrecognised pipe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,6 +63,7 @@ Suggests:
     leafem (>= 0.1.3), 
     mapedit (>= 0.6.0),
     rgdal, 
+    magrittr,
     formatR
 SystemRequirements: 
 URL: https://github.com/ropensci/MODIStsp, https://docs.ropensci.org/MODIStsp

--- a/R/MODIStsp.R
+++ b/R/MODIStsp.R
@@ -349,21 +349,26 @@ MODIStsp <- function(...,
 
   if (gui) {
     #nocov start
-    if (!all(requireNamespace(c("leaflet", "shiny",
-                                "shinydashboard","shinyFiles",
-                                "shinyalert","rappdirs", "shinyjs",
-                                "leafem", "mapedit")))) {
+    gui_deps <- c("leaflet", "shiny",
+                  "shinydashboard","shinyFiles",
+                  "shinyalert","rappdirs", "shinyjs",
+                  "leafem", "mapedit",
+                  "magrittr")
+    gui_deps_missing <- !sapply(gui_deps, requireNamespace, quietly = TRUE)
+    
+    if (sum(gui_deps_missing) > 0) {
       stop("You need to install the following Suggested packages to use the MODIStsp GUI.
            Please install them with:
            install.packages(c(\"leaflet\", \"shiny\",\"shinydashboard\",\"shinyFiles\",
                               \"shinyalert\", \"rappdirs\",\"shinyjs\",
-                              \"leafem\", \"mapedit\")")
+                              \"leafem\", \"mapedit\", \"magrittr\"))")
     } else {
       requireNamespace("leaflet")
       requireNamespace("shiny")
       requireNamespace("shinydashboard")
       requireNamespace("shinyFiles")
       requireNamespace("shinyalert")
+      requireNamespace("magrittr")
     }
     #nocov end
   }

--- a/R/MODIStsp_GUI.R
+++ b/R/MODIStsp_GUI.R
@@ -23,6 +23,11 @@ MODIStsp_GUI <- function() {
 
   server_env <- environment(MSTP_server)
 
+  # Initialise pipe
+  if (requireNamespace("magrittr", quietly = TRUE)) {
+    `%>%` <- magrittr::`%>%`
+  }
+  
   # ____________________________________________________________________________
   # Files/Folder Initialization and set-up of default parameters            ####
 

--- a/inst/app/srv/mstp_helpmess_srv.R
+++ b/inst/app/srv/mstp_helpmess_srv.R
@@ -175,7 +175,7 @@ shiny::observeEvent(input$help_spameth, {
     )),
     shiny::p(shiny::HTML(
       "<strong>Draw on Map</strong>: The user can select the extent by drawing
-      it on an interactive map;"
+      it on an interactive map."
     )),
     easyClose = TRUE,
     footer = NULL
@@ -229,8 +229,10 @@ shiny::observeEvent(input$help_user, {
       "Provide your <strong>earthdata</strong> user name." ,
     )),
    shiny::p(shiny::HTML(
-      "You can create an earthdata account at: https://urs.earthdata.nasa.gov/home"
-    )),
+     "You can create an earthdata account at:",
+     "<a href='https://urs.earthdata.nasa.gov/home'",
+     "target='_blank'>https://urs.earthdata.nasa.gov/home</a>."
+   )),
     easyClose = TRUE,
     footer = NULL
   ))
@@ -244,8 +246,10 @@ shiny::observeEvent(input$help_password, {
       "Provide your <strong>earthdata</strong> password." ,
     )),
    shiny::p(shiny::HTML(
-      "You can create an earthdata account at: https://urs.earthdata.nasa.gov/home"
-    )),
+     "You can create an earthdata account at:",
+     "<a href='https://urs.earthdata.nasa.gov/home'",
+     "target='_blank'>https://urs.earthdata.nasa.gov/home</a>."
+   )),
     easyClose = TRUE,
     footer = NULL
   ))
@@ -267,13 +271,15 @@ shiny::observeEvent(input$help_downloader, {
       "<strong><a href=\"https://aria2.github.io\" target=\"_blank\">aria2</a></strong>",
       "is an alternative downloader which can be installed in Linux systems",
       "from the default install manager (in Ubuntu, install the package \"aria2\"),",
-      "or in Windows from https://github.com/aria2/aria2/releases/tag/release-1.35.0"
+      "or in Windows from <a href='https://github.com/aria2/aria2/releases/tag/release-1.35.0'",
+      "target='_blank'>here</a>."
     )),
    shiny::p(shiny::HTML(
-      "This selector is active only if aria2 can be found using sys.which(\"aria2c\"")
-    ),
-    easyClose = TRUE,
-    footer = NULL
+     "This selector is active only if aria2 can be found using",
+     "<span style='font-family: monospace;'>Sys.which(\"aria2c\")</span>."
+   )),
+   easyClose = TRUE,
+   footer = NULL
   ))
 })
 
@@ -319,9 +325,15 @@ shiny::observeEvent(input$help_time_series, {
      processed layers as if they were a single multitemporal file."
     )),
    shiny::p(shiny::HTML("Possible choices are: ")),
-   shiny::p(shiny::HTML("<strong>R rasterStack</strong>: extension `.RData`. Can be opened in R.")),
-   shiny::p(shiny::HTML("<strong>ENVI Meta</strong>: extension `.dat`. Can be opened in R.")),
-   shiny::p(shiny::HTML("<strong>GDAL vrt</strong>: extension `.vrt`. Can be opened in QGIS and R.")),
+   shiny::p(shiny::HTML("<strong>R rasterStack</strong>:",
+                        "extension <span style='font-family: monospace;'>.RData</span>.",
+                        "Can be opened in R.")),
+   shiny::p(shiny::HTML("<strong>ENVI Meta</strong>:",
+                        "extension <span style='font-family: monospace;'>.dat</span>.",
+                        "Can be opened in R.")),
+   shiny::p(shiny::HTML("<strong>GDAL vrt</strong>:",
+                        "extension <span style='font-family: monospace;'>.vrt</span>.",
+                        "Can be opened in QGIS and R.")),
 
    shiny::p(shiny::HTML("Time series files are saved in the <em>\"time_series\"</em> subfolder of the main
     output folder")),

--- a/inst/app/ui/mstp_other_ui.R
+++ b/inst/app/ui/mstp_other_ui.R
@@ -153,8 +153,8 @@ shinydashboard::tabItem(
           style = "display:inline-block;margin-right:5px;width:15%;vertical-align:top",
           shiny::selectInput(
             "reprocess",
-            label = shiny::span("Reprocess\u2000",
-                         shiny::actionLink("help_reprocess", shiny::icon("question-circle"))
+            label = shiny::span("Reprocess\u2000"#,
+                         # shiny::actionLink("help_reprocess", shiny::icon("question-circle"))
             ),
             c("Yes", "No"), selected = "No"
           )
@@ -185,8 +185,8 @@ shinydashboard::tabItem(
           style = "display:inline-block;margin-right:5px;width:15%;vertical-align:top",
           shiny::selectInput(
             "delete_hdf",
-            label = shiny::span("Delete HDF\u2000",
-                         shiny::actionLink("help_delete", shiny::icon("question-circle"))
+            label = shiny::span("Delete HDF\u2000"#,
+                         # shiny::actionLink("help_delete", shiny::icon("question-circle"))
             ),
             c("Yes", "No"), selected = "Yes"
           )


### PR DESCRIPTION
Launching `MODIStsp()`, the following error appears:
```
> library(MODIStsp)
> MODIStsp()
Loading required namespace: leaflet
Loading required namespace: shiny
Loading required namespace: shinydashboard
Loading required namespace: shinyFiles
Loading required namespace: shinyalert
GDAL version in use: 2.2.3
Loading required package: shiny

Listening on http://127.0.0.1:7963
Warning: Error in %>%: non trovo la funzione "%>%"
  46: <observer> [/home/lranghetti/R/x86_64-pc-linux-gnu-library/3.6/MODIStsp/app/srv/mstp_spatemp_srv_tiles.R#109]
   3: shiny::runApp
   2: MODIStsp_GUI
   1: MODIStsp
```
This pull requests fixes that.

Moreover, the check for packages required by the GUI was edited in order to properly work for all the packages (this because `requireNamespace()` works on single package names).