### PR TITLE
Delete old issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,0 @@
-<!--
-If you need to ask for help, report a bug or make a question about {MODIStsp} functionalities, please use a specific template choosing from https://github.com/ropensci/MODIStsp/issues/new/choose . In case of doubts, you should probably use the "Help needed" template.
-Before opening a new issue please check if the topic was already threated (if so but the found issue is closed, open a new issue citing the old task instead than reopening it).
--->


### PR DESCRIPTION
Cf https://docs.github.com/articles/about-issue-and-pull-request-templates -- but if I follow correctly you already have "modern" issue templates.

The presence of this file provoked a pkgdown error cf https://github.com/r-universe/ropensci/runs/4511973450?check_suite_focus=true