### PR TITLE
revise MODIStsp_download.R httr::authenticate type from "basic" to "any"

### DIFF
--- a/R/MODIStsp_download.R
+++ b/R/MODIStsp_download.R
@@ -73,7 +73,7 @@ MODIStsp_download <- function(modislist,
 
         size_string <- httr::RETRY("GET",
                                    paste0(remote_filename, ".xml"),
-                                   httr::authenticate(user, password),
+                                   httr::authenticate(user, password, type = "any"),
                                    times = n_retries,
                                    pause_base = 0.1,
                                    pause_cap = 10,
@@ -142,7 +142,7 @@ MODIStsp_download <- function(modislist,
           } else {
             # http download - httr
             download <- try(httr::GET(remote_filename,
-                                      httr::authenticate(user, password),
+                                      httr::authenticate(user, password, type = "any"),
                                       # httr::progress(),
                                       httr::write_disk(local_filename,
                                                        overwrite = TRUE)))


### PR DESCRIPTION
We revise the authenticate type to "any", default is "basic". If keeping default always 401 status, now it may be 200. 

This happens after the maintenance of the U.S. GOVERNMENT COMPUTER.

We have already tested the revision. It works. 