### PR TITLE
Fix badges paragraph for detection by pkgdown

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -13,13 +13,15 @@ knitr::opts_chunk$set(
   fig.path = "README-"
 )
 ```
+# MODIStsp <img src='man/figures/logo.png' align="right" height="139" />
+
+<!-- badges: start -->
 [![](https://www.r-pkg.org/badges/version-ago/MODIStsp)](https://cran.r-project.org/package=MODIStsp)
 [![](https://cranlogs.r-pkg.org/badges/MODIStsp?color=orange)](https://cran.r-project.org/package=MODIStsp)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1972039.svg)](https://doi.org/10.5281/zenodo.1972039)
 [![Coverage Status](https://img.shields.io/codecov/c/github/ropensci/MODIStsp/master.svg)](https://codecov.io/github/ropensci/MODIStsp?branch=master)
 [![](https://badges.ropensci.org/184_status.svg)](https://github.com/ropensci/software-review/issues/184)
-
-# MODIStsp <img src='man/figures/logo.png' align="right" height="139" />
+<!-- badges: end -->
 
 [`{MODIStsp}`](https://docs.ropensci.org/MODIStsp/) is a `R` package devoted to
 automatizing the creation of time series of rasters derived from MODIS Land Products


### PR DESCRIPTION
:warning: I haven't rendered `README.Rmd`.

This change is for pkgdown to find the badges paragraph and put it in the sidebar. https://pkgdown.r-lib.org/reference/build_home.html#dev-badges

At the moment the badges have to be after the header see https://github.com/r-lib/pkgdown/issues/2060