### PR TITLE
Remove geojsonlint from list of dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,6 @@ Suggests:
     dplyr,
     DT,
     formatR,
-    geojsonlint,
     ggplot2,
     grid,
     httptest,


### PR DESCRIPTION
As we haven't found (yet?) a new maintainer for {geojsonlint} I am having a closer look at its reverse dependencies as we might need to archive it on CRAN and GitHub.
I see that in MODIStsp, it is mentioned in DESCRIPTION and nowhere else so probably harmless to remove?

If you merge this, can you tell me when you'd update it on CRAN?

Slightly related, are there other unused dependencies in Suggests?

Thank you :pray: